### PR TITLE
Support logging in to a private registry before launch

### DIFF
--- a/jobs/docker/spec
+++ b/jobs/docker/spec
@@ -132,3 +132,10 @@ properties:
   store_dir:
     description: "Path to use as the root of the Docker runtime"
     default: "/var/vcap/store"
+
+  logins:
+    description: "List of hashes containing registries to log in to and their credentials"
+    example: |
+      - endpoint: https://my.private.registry.local/
+        username: foo
+        password: bar

--- a/jobs/docker/templates/bin/ctl
+++ b/jobs/docker/templates/bin/ctl
@@ -45,7 +45,7 @@ case $1 in
     fi
 
     # Start Docker daemon
-    exec dockerd \
+    nohup dockerd \
         ${DOCKER_BRIDGE:-} \
         ${DOCKER_DEBUG} \
         ${DOCKER_DEFAULT_GATEWAY:-} \
@@ -84,7 +84,18 @@ case $1 in
         ${DOCKER_USERLAND_PROXY} \
         ${DOCKER_BIP:-} \
         >>${DOCKER_LOG_DIR}/${OUTPUT_LABEL}.stdout.log \
-        2>>${DOCKER_LOG_DIR}/${OUTPUT_LABEL}.stderr.log
+        2>>${DOCKER_LOG_DIR}/${OUTPUT_LABEL}.stderr.log \
+        &
+
+    while [ ! -S ${DOCKER_PID_DIR}/docker.sock ];do
+      sleep .5
+    done
+
+    # Log in to any registries
+<% p('logins', []).each do |login| %>
+    /var/vcap/packages/docker/bin/docker -H unix://${DOCKER_PID_DIR}/docker.sock login \
+      --username <%= login['username'] %> --password <%= login['password'] %> <%= login['endpoint'] %>
+<% end %>
     ;;
 
   stop)


### PR DESCRIPTION
Simple patch that adds a few attributes to the job's properties to support logging in to a private registry.