### PR TITLE
Explicitly unmount overlayfs

### DIFF
--- a/jobs/docker/templates/bin/ctl
+++ b/jobs/docker/templates/bin/ctl
@@ -102,6 +102,9 @@ case $1 in
     # Stop Docker daemon
     echo -n "Stopping docker daemon..."
     kill_and_wait ${DOCKER_PID_FILE}
+    if grep -qs '/var/vcap/store/docker/docker/overlay' /proc/mounts; then
+      umount /var/vcap/store/docker/docker/overlay
+    fi
     ;;
 
   *)


### PR DESCRIPTION
We discovered a problem when bosh is unmounting `/var/vcap/store`, and the `/var/vcap/store/docker/docker/overlay` is still mounted. 
`kill_and_wait` can force kill `dockerd` with `kill -9`, which leaves the `/var/vcap/store/docker/docker/overlay` fs still mounted.