### PR TITLE
Add logging of /proc/mounts in docker stop

### DIFF
--- a/jobs/docker/templates/bin/ctl
+++ b/jobs/docker/templates/bin/ctl
@@ -102,6 +102,9 @@ case $1 in
     # Stop Docker daemon
     echo -n "Stopping docker daemon..."
     kill_and_wait ${DOCKER_PID_FILE}
+    echo "DEBUG: Contents of /proc/mounts after stopping docker"
+    cat /proc/mounts
+
     if grep -qs '/var/vcap/store/docker/docker/overlay' /proc/mounts; then
       umount /var/vcap/store/docker/docker/overlay
     fi


### PR DESCRIPTION
We added the umount of the overlay file which we think is causing the
intermittent bug we see. However, this log line will help us debug if
that wasn't the cause and we see the problem again.

[#156017255]

Signed-off-by: Carlo Colombo <ccolombo@pivotal.io>