### PR TITLE
--data-root flag replaces --graph

### DIFF
--- a/jobs/docker/templates/bin/ctl
+++ b/jobs/docker/templates/bin/ctl
@@ -57,7 +57,7 @@ case $1 in
         ${DOCKER_DNS_SEARCH:-} \
         ${DOCKER_EXEC_OPTIONS:-} \
         --group vcap \
-        --graph ${DOCKER_STORE_DIR}/docker \
+        --data-root ${DOCKER_STORE_DIR}/docker \
         --host unix://${DOCKER_PID_DIR}/docker.sock \
         ${DOCKER_ICC} \
         ${DOCKER_INSECURE_REGISTRIES:-} \


### PR DESCRIPTION
Fixes warning:
time="2018-05-01T21:41:18Z" level=warning msg="The \"-g / --graph\" flag is deprecated. Please use \"--data-root\" instead"