### PR TITLE
add an option to enable shared_mounts

### DIFF
--- a/jobs/docker/spec
+++ b/jobs/docker/spec
@@ -100,6 +100,9 @@ properties:
     description: "Use a specific storage driver"
   storage_options:
     description: "Array of storage driver options"
+  shared_mounts_enable:
+    description: "Enable shared_mounts"
+    default: false
 
   userland_proxy:
     description: "Use userland proxy for loopback traffic"

--- a/jobs/docker/templates/bin/ctl
+++ b/jobs/docker/templates/bin/ctl
@@ -44,6 +44,9 @@ case $1 in
         set -e
     fi
 
+    # Enable shared_mounts
+    [ "${DOCKER_SHARED_MOUNTS_ENABLE}" = "true" ] && mount --make-shared /
+
     # Start Docker daemon
     exec dockerd \
         ${DOCKER_BRIDGE:-} \

--- a/jobs/docker/templates/bin/job_properties.sh.erb
+++ b/jobs/docker/templates/bin/job_properties.sh.erb
@@ -140,6 +140,9 @@ export DOCKER_REGISTRY_MIRRORS="<%= registry_mirrors.map { |registry_mirror| "--
 # Enable selinux support
 export DOCKER_SELINUX_ENABLED="--selinux-enabled=<%= p('selinux_enable') %>"
 
+# Enable shared_mounts
+export DOCKER_SHARED_MOUNTS_ENABLE=<%= p('shared_mounts_enable') %>
+
 <% if_p('storage_driver') do |storage_driver| %>
 # Use a specific storage driver
 export DOCKER_STORAGE_DRIVER="--storage-driver=<%= storage_driver %>"


### PR DESCRIPTION
CSI support in Kubernetes requires shared mounts to be enabled. Please see:

1. https://kubernetes-csi.github.io/docs/Setup.html
1. https://docs.portworx.com/knowledgebase/shared-mount-propagation.html#ubuntu-configuration-and-shared-mounts