### PR TITLE
Add extra cgroup mounts for bosh-lite environments

### DIFF
--- a/jobs/docker/templates/bin/cgroupfs-mount
+++ b/jobs/docker/templates/bin/cgroupfs-mount
@@ -12,26 +12,14 @@ fi
 
 (
   cd /sys/fs/cgroup
-  for sys in $(awk '!/^#/ { if ($4 == 1) print $1 }' /proc/cgroups); do
-    mkdir -p $sys
+  for sys in $(awk -F: '{print $2}' /proc/self/cgroup); do
+    mkdir -p $sys/name=/
     if ! mountpoint -q $sys; then
-      if ! mount -n -t cgroup -o $sys cgroup $sys; then
-        rmdir $sys || true
+      if ! mount -n -t cgroup -o $sys cgroup $sys/name=/; then
+        rmdir $sys/name=/ || true
       fi
     fi
   done
-  
-  if grep -q warden /var/vcap/bosh/etc/infrastructure; then
-    for sys in $(printf "systemd\nunified\ncpu\ncpuacct\nnet_cls\nnet_prio"); do
-      mkdir -p $sys
-    done
-    mount -t cgroup -o rw,nosuid,nodev,noexec,relatime,xattr,name=systemd cgroup /sys/fs/cgroup/systemd
-    mount -t cgroup2 -o rw,nosuid,nodev,noexec,relatime,nsdelegate  cgroup /sys/fs/cgroup/unified
-    mount -t cgroup -o rw,nosuid,nodev,noexec,relatime,cpu,cpuacct cgroup /sys/fs/cgroup/cpu
-    mount -t cgroup -o rw,nosuid,nodev,noexec,relatime,cpu,cpuacct cgroup /sys/fs/cgroup/cpuacct
-    mount -t cgroup -o rw,nosuid,nodev,noexec,relatime,net_cls,net_prio cgroup /sys/fs/cgroup/net_cls
-    mount -t cgroup -o rw,nosuid,nodev,noexec,relatime,net_cls,net_prio cgroup /sys/fs/cgroup/net_prio
-  fi
 )
 
 exit 0

--- a/jobs/docker/templates/bin/cgroupfs-mount
+++ b/jobs/docker/templates/bin/cgroupfs-mount
@@ -12,14 +12,25 @@ fi
 
 (
   cd /sys/fs/cgroup
-  for sys in $(awk -F: '{print $2}' /proc/self/cgroup); do
-    mkdir -p $sys/name=/
-    if ! mountpoint -q $sys; then
-      if ! mount -n -t cgroup -o $sys cgroup $sys/name=/; then
-        rmdir $sys/name=/ || true
+  if grep -q warden /var/vcap/bosh/etc/infrastructure; then
+    for sys in $(awk -F: '{print $2}' /proc/self/cgroup); do
+      mkdir -p $sys/name=/
+      if ! mountpoint -q $sys; then
+        if ! mount -n -t cgroup -o $sys cgroup $sys/name=/; then
+          rmdir $sys/name=/ || true
+        fi
       fi
-    fi
-  done
+    done
+  else
+    for sys in $(awk '!/^#/ { if ($4 == 1) print $1 }' /proc/cgroups); do
+      mkdir -p $sys
+      if ! mountpoint -q $sys; then
+        if ! mount -n -t cgroup -o $sys cgroup $sys; then
+          rmdir $sys || true
+        fi
+      fi
+    done
+  fi
 )
 
 exit 0

--- a/jobs/docker/templates/bin/cgroupfs-mount
+++ b/jobs/docker/templates/bin/cgroupfs-mount
@@ -14,10 +14,23 @@ fi
   cd /sys/fs/cgroup
   if grep -q warden /var/vcap/bosh/etc/infrastructure; then
     for sys in $(awk -F: '{print $2}' /proc/self/cgroup); do
-      mkdir -p $sys/name=/
-      if ! mountpoint -q $sys; then
-        if ! mount -n -t cgroup -o $sys cgroup $sys/name=/; then
-          rmdir $sys/name=/ || true
+      if [ $(echo $sys | grep -c ',') -gt 0 ]
+      then
+        for cgroup in $(echo $sys | sed 's/,/\n/'); do
+          mkdir -p $cgroup
+          if ! mountpoint -q $cgroup; then
+            if ! mount -n -t cgroup -o $sys cgroup $cgroup; then
+              rmdir $cgroup || true
+            fi
+          fi
+        done
+      else
+        cgroup=$(echo $sys | sed 's/name=//')
+        mkdir -p $cgroup
+        if ! mountpoint -q $sys; then
+          if ! mount -n -t cgroup -o $sys cgroup $cgroup; then
+            rmdir $cgroup || true
+          fi
         fi
       fi
     done

--- a/jobs/docker/templates/bin/cgroupfs-mount
+++ b/jobs/docker/templates/bin/cgroupfs-mount
@@ -20,6 +20,18 @@ fi
       fi
     fi
   done
+  
+  if grep -q warden /var/vcap/bosh/etc/infrastructure; then
+    for sys in $(printf "systemd\nunified\ncpu\ncpuacct\nnet_cls\nnet_prio"); do
+      mkdir -p $sys
+    done
+    mount -t cgroup -o rw,nosuid,nodev,noexec,relatime,xattr,name=systemd cgroup /sys/fs/cgroup/systemd
+    mount -t cgroup2 -o rw,nosuid,nodev,noexec,relatime,nsdelegate  cgroup /sys/fs/cgroup/unified
+    mount -t cgroup -o rw,nosuid,nodev,noexec,relatime,cpu,cpuacct cgroup /sys/fs/cgroup/cpu
+    mount -t cgroup -o rw,nosuid,nodev,noexec,relatime,cpu,cpuacct cgroup /sys/fs/cgroup/cpuacct
+    mount -t cgroup -o rw,nosuid,nodev,noexec,relatime,net_cls,net_prio cgroup /sys/fs/cgroup/net_cls
+    mount -t cgroup -o rw,nosuid,nodev,noexec,relatime,net_cls,net_prio cgroup /sys/fs/cgroup/net_prio
+  fi
 )
 
 exit 0

--- a/manifests/operators/add_support_for_bosh_lite.yml
+++ b/manifests/operators/add_support_for_bosh_lite.yml
@@ -1,0 +1,5 @@
+---
+# required to run docker-boshrelease on bosh-lite
+- type: replace
+  path: /instance_groups/name=docker?/persistent_disk
+  value: 1024

--- a/manifests/operators/dev.yml
+++ b/manifests/operators/dev.yml
@@ -4,3 +4,8 @@
   value:
     name: docker
     version: latest
+
+# required to run docker-boshrelease on bosh-lite
+- type: replace
+  path: /instance_groups/name=docker?/persistent_disk
+  value: 1024

--- a/manifests/operators/dev.yml
+++ b/manifests/operators/dev.yml
@@ -4,8 +4,3 @@
   value:
     name: docker
     version: latest
-
-# required to run docker-boshrelease on bosh-lite
-- type: replace
-  path: /instance_groups/name=docker?/persistent_disk
-  value: 1024


### PR DESCRIPTION
When deploying onto a bosh-lite environment using a persistent disk I am unable to execute:
```
docker run hello-world
```
However adding the extra code (_my mish-mashed understanding of configuring cgroups - apologies_) contained in the PR it executes successfully.