### PR TITLE
Handle multiline environment variables correctly

### DIFF
--- a/jobs/containers/templates/bin/ctl
+++ b/jobs/containers/templates/bin/ctl
@@ -85,7 +85,7 @@ case $1 in
       "$(eval echo "\$${container_name}_command")" \
     "
     echo "$(date) Running Docker command with options: ${docker_options}"
-    ${DOCKER_COMMAND}  ${docker_options} \
+    eval echo ${docker_options} | xargs ${DOCKER_COMMAND}  \
         >>${LOG_DIR}/${OUTPUT_LABEL}.stdout.log \
         2>>${LOG_DIR}/${OUTPUT_LABEL}.stderr.log
 


### PR DESCRIPTION
When using a multiline variable, the variable has unevaluated elements.
This change evaluates so that those elements are resolved.