### PR TITLE
Fixed the path for docker store to use the environment variable

### DIFF
--- a/jobs/docker/templates/bin/ctl
+++ b/jobs/docker/templates/bin/ctl
@@ -9,7 +9,7 @@ export DOCKER_PID_FILE=${DOCKER_PID_DIR}/docker.pid
 export PATH="/var/vcap/packages/docker/bin:$PATH"
 
 function remove_docker_network_db(){
-    rm -f /var/vcap/data/docker/docker/network/files/local-kv.db
+    rm -f ${DOCKER_STORE_DIR}/docker/network/files/local-kv.db
 }
 
 function create_network_bridge(){


### PR DESCRIPTION
- since this needs to work the same way in cfcr and pks

[#164498025](https://www.pivotaltracker.com/story/show/164498025)
PKS Flannel Network Gets Out of Sync with Docker Bridge Network (cni0)Dock

Co-authored-by: Sudhindra Rao <surao@pivotal.io>
Co-authored-by: Ivan Mikushin <imikushin@vmware.com>

```release-note
Fixed the path for docker store to use the environment variable 
- since this needs to work the same way in CFCR and PKS

This fixes issue:
[#164498025](https://www.pivotaltracker.com/story/show/164498025)
PKS Flannel Network Gets Out of Sync with Docker Bridge Network (cni0)
```