### PR TITLE
Fix windows docker default config directory

### DIFF
--- a/jobs/docker-windows/templates/daemon-config.ps1.erb
+++ b/jobs/docker-windows/templates/daemon-config.ps1.erb
@@ -26,7 +26,7 @@ if (!(Test-Path "$dataRootBase\docker-windows")) {
   mkdir "$dataRootBase\docker-windows"
 }
 
-$dockerDataDir = "$env:ProgramData\docker-windows"
+$dockerDataDir = "$env:ProgramData\docker"
 
 $dockerConfigDir = "$dockerDataDir\config"
 if (!(Test-Path $dockerConfigDir)) {


### PR DESCRIPTION
This directory name appears to have been incorrectly changed with the rename to `docker-windows`. Unfortunately, the default directory appears to be hard-coded in docker and to specifically be `$env:ProgramData\docker`.

This change should allow the config to be created in docker's expected location and the config should point to bosh-managed directories.